### PR TITLE
sendOrUnregisterの修正

### DIFF
--- a/usecases/service/ws/client.go
+++ b/usecases/service/ws/client.go
@@ -142,7 +142,7 @@ func (c *Client) bloadcast(next func(c *Client)) {
 
 func (c *Client) sendOrUnregister(cc *Client, msg []byte) {
 	select {
-	case c.send <- msg:
+	case cc.send <- msg:
 	default:
 		c.hub.unregister(cc)
 	}

--- a/usecases/service/ws/client.go
+++ b/usecases/service/ws/client.go
@@ -145,6 +145,9 @@ func (c *Client) sendOrUnregister(cc *Client, msg []byte) {
 	case cc.send <- msg:
 	default:
 		c.hub.unregister(cc)
+		if cc.userId == c.room.HostId {
+			c.sendChangeHostEvent()
+		}
 	}
 }
 

--- a/usecases/service/ws/handler.go
+++ b/usecases/service/ws/handler.go
@@ -745,7 +745,7 @@ func (c *Client) sendNextRoomEvent() error {
 // TODO: 実装する
 // CHANGE_HOST
 // ホストが落ちた時に飛んできて，ホスト役を変更する (サーバー -> ルーム全員)
-func (c *Client) sendChangeHostEvent(body interface{}) error {
+func (c *Client) sendChangeHostEvent() error {
 	return nil
 }
 


### PR DESCRIPTION
- :bug: 送信先ミス
- :sparkles: Add sendChangeHostEvent to c.sendOrUnregister
