### PR TITLE
エラーハンドリングの修正

### DIFF
--- a/interfaces/handler/errors.go
+++ b/interfaces/handler/errors.go
@@ -8,7 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func newEchoHTTPError(err error) error {
+func newEchoHTTPError(err error, c echo.Context) error {
 	switch {
 	case errors.Is(err, repository.ErrNotFound):
 		return echo.NewHTTPError(http.StatusNotFound, err.Error())
@@ -17,6 +17,7 @@ func newEchoHTTPError(err error) error {
 	case errors.Is(err, repository.ErrForbidden):
 		return echo.NewHTTPError(http.StatusForbidden, err.Error())
 	default:
+		c.Logger().Error(err.Error())
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 }

--- a/interfaces/handler/room.go
+++ b/interfaces/handler/room.go
@@ -25,7 +25,7 @@ func (h *handler) JoinRoom(c echo.Context) error {
 		Username: model.Username(req.Username),
 	})
 	if err != nil {
-		return newEchoHTTPError(err)
+		return newEchoHTTPError(err, c)
 	}
 
 	// Notify Other Clients of the new user with WebSocket
@@ -51,7 +51,7 @@ func (h *handler) CreateRoom(c echo.Context) error {
 		Username: model.Username(req.Username),
 	})
 	if err != nil {
-		return newEchoHTTPError(err)
+		return newEchoHTTPError(err, c)
 	}
 
 	return echo.NewHTTPError(http.StatusCreated, oapi.RefillRoom(room, room.HostId))
@@ -60,7 +60,7 @@ func (h *handler) CreateRoom(c echo.Context) error {
 func (h *handler) GetRoom(c echo.Context, roomId oapi.RoomIdInPath) error {
 	room, err := h.r.GetRoom(model.RoomId(roomId))
 	if err != nil {
-		return newEchoHTTPError(err)
+		return newEchoHTTPError(err, c)
 	}
 
 	return echo.NewHTTPError(http.StatusOK, oapi.RefillRoom(room, model.UserId{})) // ユーザーIDが必要ないのでとりあえずuuid.Nilにしておく

--- a/interfaces/handler/room.go
+++ b/interfaces/handler/room.go
@@ -63,5 +63,5 @@ func (h *handler) GetRoom(c echo.Context, roomId oapi.RoomIdInPath) error {
 		return newEchoHTTPError(err)
 	}
 
-	return c.JSON(http.StatusOK, oapi.RefillRoom(room, model.UserId{})) // ユーザーIDが必要ないのでとりあえずuuid.Nilにしておく
+	return echo.NewHTTPError(http.StatusOK, oapi.RefillRoom(room, model.UserId{})) // ユーザーIDが必要ないのでとりあえずuuid.Nilにしておく
 }

--- a/interfaces/handler/ws.go
+++ b/interfaces/handler/ws.go
@@ -15,8 +15,7 @@ func (h *handler) Ws(c echo.Context, params oapi.WsParams) error {
 	}
 
 	if err := h.stream.ServeWS(c.Response().Writer, c.Request(), uid); err != nil {
-		c.Logger().Error(err)
-		return newEchoHTTPError(err)
+		return newEchoHTTPError(err, c)
 	}
 
 	return c.NoContent(http.StatusNoContent)

--- a/interfaces/handler/ws.go
+++ b/interfaces/handler/ws.go
@@ -1,9 +1,11 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/21hack02win/nascalay-backend/oapi"
+	"github.com/21hack02win/nascalay-backend/usecases/repository"
 	"github.com/labstack/echo/v4"
 )
 
@@ -14,7 +16,8 @@ func (h *handler) Ws(c echo.Context, params oapi.WsParams) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	if err := h.stream.ServeWS(c.Response().Writer, c.Request(), uid); err != nil {
+	err = h.stream.ServeWS(c.Response().Writer, c.Request(), uid)
+	if err != nil && !errors.Is(err, repository.ErrNotFound) {
 		return newEchoHTTPError(err, c)
 	}
 


### PR DESCRIPTION
- :recycle: Use echo.NewHTTPError
- :recycle: Log when 500
- :recycle: GET /wsの404エラーを出力しない
