### PR TITLE
クライアントに送るメッセージをJSONに統一

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -281,6 +281,7 @@ components:
         - NEXT_ROOM
         - CHANGE_HOST
         - BREAK_ROOM
+        - WELCOME_NEW_CLIENT
         - ERROR
     WsReceiveMessage:
       title: WsReceiveMessage
@@ -309,6 +310,7 @@ components:
               $ref: '#/components/schemas/WsEvent'
             body:
               oneOf:
+                - $ref: '#/components/schemas/WsWelcomeNewClientBody'
                 - $ref: '#/components/schemas/WsErrorBody'
                 - $ref: '#/components/schemas/WsRoomNewMemberEventBody'
                 - $ref: '#/components/schemas/WsRoomUpdateOptionEventBody'
@@ -333,6 +335,18 @@ components:
         - canvas
         - answer
         - end
+    WsWelcomeNewClientBody:
+      title: WsWelcomeNewClientBody
+      type: object
+      description: 接続時に送信する (サーバー -> 新規クライアント)
+      example:
+        content: Welcome to nascalay-backend!
+      properties:
+        content:
+          type: string
+          description: 接続確認メッセージ
+      required:
+        - content
     WsErrorBody:
       title: WsErrorBody
       type: object

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -76,13 +76,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/WsReceiveMessage'
+                $ref: '#/components/schemas/WsSendMessage'
       operationId: ws
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/WsSendMessage'
+              $ref: '#/components/schemas/WsReceiveMessage'
         description: ''
       description: |-
         Websocketを送受信する

--- a/oapi/types.go
+++ b/oapi/types.go
@@ -317,7 +317,7 @@ type JoinRoomJSONBody JoinRoomRequest
 type CreateRoomJSONBody CreateRoomRequest
 
 // WsJSONBody defines parameters for Ws.
-type WsJSONBody WsSendMessage
+type WsJSONBody WsReceiveMessage
 
 // WsParams defines parameters for Ws.
 type WsParams struct {

--- a/oapi/types.go
+++ b/oapi/types.go
@@ -64,6 +64,8 @@ const (
 	WsEventSHOWODAI WsEvent = "SHOW_ODAI"
 
 	WsEventSHOWSTART WsEvent = "SHOW_START"
+
+	WsEventWELCOMENEWCLIENT WsEvent = "WELCOME_NEW_CLIENT"
 )
 
 // Defines values for WsNextShowStatus.
@@ -302,6 +304,12 @@ type WsShowOdaiEventBody struct {
 
 	// ユーザー情報
 	Sender User `json:"sender"`
+}
+
+// 接続時に送信する (サーバー -> 新規クライアント)
+type WsWelcomeNewClientBody struct {
+	// 接続確認メッセージ
+	Content string `json:"content"`
 }
 
 // ルームID

--- a/usecases/service/ws/util.go
+++ b/usecases/service/ws/util.go
@@ -22,7 +22,7 @@ func (c *Client) bloadcast(next func(c *Client)) {
 }
 
 // Send message to a client
-func (c *Client) sendMsg(msg []byte) {
+func (c *Client) sendMsg(msg *oapi.WsSendMessage) {
 	if c.send == nil {
 		if c.userId == c.room.HostId {
 			if err := c.sendChangeHostEvent(); err != nil {
@@ -38,7 +38,7 @@ func (c *Client) sendMsg(msg []byte) {
 }
 
 // Send message to all clients in the room
-func (c *Client) sendMsgToEachClientInRoom(msg []byte) {
+func (c *Client) sendMsgToEachClientInRoom(msg *oapi.WsSendMessage) {
 	c.bloadcast(func(cc *Client) {
 		cc.sendMsg(msg)
 	})

--- a/usecases/service/ws/ws.go
+++ b/usecases/service/ws/ws.go
@@ -53,7 +53,12 @@ func (s *streamer) ServeWS(w http.ResponseWriter, r *http.Request, userId model.
 	go cli.writePump()
 	go cli.readPump()
 
-	cli.send <- []byte("Welcome to nascalay-backend!")
+	cli.send <- &oapi.WsSendMessage{
+		Type: oapi.WsEventWELCOMENEWCLIENT,
+		Body: oapi.WsWelcomeNewClientBody{
+			Content: "Welcome to nascalay-backend!",
+		},
+	}
 
 	return nil
 }


### PR DESCRIPTION
warning出てたの嫌だったので

- :bug: Fix openapi type
- :memo: Add WsWelcomeNewClientBody
- :boom: Clientに送るメッセージをjson形式に統一
